### PR TITLE
fix(deployment): circumvent git-hook

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 deploy:
 	@rm -rf ./build
 	@wintersmith build
-	@cd ./build && git init . && git add . && git commit -m \"Deployment\" && \
+	@cd ./build && git init . && git add . && git commit -nm \"Deployment\" && \
 	git push "git@github.com:jsunconf/2015.jsunconf.eu.git" master:gh-pages --force && rm -rf .git
 	@rm -rf ./build


### PR DESCRIPTION
I have a global pre-commot-hook which does not let me commit if
there is no newline on the end of the file, as many open source
projects complain (and they're right!) if I submit a PR and don't
follow this.

As the generated stuff from wintersmith often does not have
newlines, I do not want my git-hook to yell at me when deploying.
