### PR TITLE
Add fix for link causes overflow-x

### DIFF
--- a/contents/css/main.styl
+++ b/contents/css/main.styl
@@ -31,6 +31,7 @@ a
   text-decoration: none
   color: $red-violet
   transition: color .2s
+  word-break: break-all
   &:hover, &:focus
     text-decoration: underline
 


### PR DESCRIPTION
![link-cause-overflow](https://cloud.githubusercontent.com/assets/1640079/6187025/b7ba04aa-b381-11e4-8d8f-3d79887d3524.png)
Long links cause overflow-x which leads to visual bugs on small view ports. 